### PR TITLE
Update ci/cd auth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,26 +9,16 @@ jobs:
     name: ETL
     runs-on: ubuntu-latest
     environment: OS
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.IAM_ROLE }}
-        aws-region: us-west-2
-
     - name: Install deps
-      run: |
-        npm install
+      run: npm install
 
     - name: Run ETL
       env:
         OS_ENDPOINT: ${{ secrets.OS_ENDPOINT }}
-      run: |
-        npm run etl
+        OS_USERNAME: ${{ secrets.OS_USERNAME }}
+        OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+      run: npm run etl


### PR DESCRIPTION
This is to update our CI/CD to use basic auth rather than using an assumed web identity.

The action failure is expected as we don't have the update in our opensearch client yet.