### PR TITLE
Only want issues in issues_only.json

### DIFF
--- a/src/scripts/extract.ts
+++ b/src/scripts/extract.ts
@@ -10,7 +10,7 @@ async function extract() {
 
   //get issues and write them to output/issues.json
   const issues = await githubClient.getIssues();
-  await write("issues.json", issues);
+  await write("issues_only.json", issues);
 
   // get actions and write them to output/actions.json
   const actions = await githubClient.getWorkflowRuns();


### PR DESCRIPTION
Since getIssues() API will get both pull requests and issues, rename the issues.json to issues_only.json to only include issues