### PR TITLE
Adding Support for Jobs

### DIFF
--- a/src/clients/GithubClient.ts
+++ b/src/clients/GithubClient.ts
@@ -10,7 +10,7 @@ import { RequestInterface, RequestParameters } from "@octokit/types";
 
 const ORG = "opensearch-project";
 const DEFAULT_REPO = "Opensearch-Dashboards";
-const BACKFILL = new Date().getDate() % 2 === 0;
+const BACKFILL = process.env.OS_BACKFILL === "true";
 const PAGE_SIZE = 100;
 
 type GithubClientConfig = {

--- a/src/scripts/extract.ts
+++ b/src/scripts/extract.ts
@@ -15,6 +15,10 @@ async function extract() {
   // get actions and write them to output/actions.json
   const actions = await githubClient.getWorkflowRuns();
   await write("actions.json", actions);
+
+  // get action jobs and write them to output/jobs.json
+  const jobs = await githubClient.getJobs();
+  await write("jobs.json", jobs);
 }
 
 extract();

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,7 @@ export type ActionRuns =
 export type WorkflowRun =
   ActionRuns["workflow_runs"][0];
 
+export type JobRun = 
+ Endpoints["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"]["response"]["data"]
+
 export type Document = Record<string, unknown> & { id: number };


### PR DESCRIPTION
also did a really quick implementation of backfilling every other day (still will run on end/start of months with 31 days) in case we don't want it to keep going every day